### PR TITLE
fix-DefaultController

### DIFF
--- a/src/AppBundle/Controller/DefaultController.php
+++ b/src/AppBundle/Controller/DefaultController.php
@@ -2,16 +2,32 @@
 
 namespace AppBundle\Controller;
 
-use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
-use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Twig\Environment;
 
-class DefaultController extends Controller
+class DefaultController
 {
+    /** @var Environment */
+    protected $twig;
+
+    public function __construct(
+        Environment $twig
+    ) {
+        $this->twig = $twig;
+    }
+
     /**
      * @Route("/", name="homepage")
+     * @return Response
+     * @throws \Twig\Error\LoaderError
+     * @throws \Twig\Error\RuntimeError
+     * @throws \Twig\Error\SyntaxError
      */
     public function indexAction()
     {
-        return $this->render('default/index.html.twig');
+        return new Response(
+            $this->twig->render('default/index.html.twig')
+        );
     }
 }


### PR DESCRIPTION
Remove extends Controller to class DefaultController.
Dependency injection Twig\Environment and use Symfony\Component\Routing\Annotation\Route.